### PR TITLE
Use new UI API

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,7 @@
 local save = ya.sync(function(this, cwd, output)
 	if cx.active.current.cwd == Url(cwd) then
 		this.output = output
-		ya.render()
+		ui.render()
 	end
 end)
 


### PR DESCRIPTION
UI methods were moved out of `ya` to the `ui` namespace in https://github.com/sxyazi/yazi/pull/2939. This is a simple rename, but removes the annoying warning message